### PR TITLE
Refactor: Remove developmental and unnecessary comments

### DIFF
--- a/src/llm_benchmarks/data/gsm8k.py
+++ b/src/llm_benchmarks/data/gsm8k.py
@@ -29,7 +29,6 @@ class GSM8KDataset:
                 f"Invalid config '{config}'. Please choose 'main' or 'socratic'."
             )
 
-        # Load the specified split of the gsm8k dataset from Hugging Face
         try:
             self.dataset = load_dataset("gsm8k", name=config, split=split)
         except Exception as e:

--- a/src/llm_benchmarks/main.py
+++ b/src/llm_benchmarks/main.py
@@ -1,30 +1,24 @@
-import logging # Still needed for logger = logging.getLogger(__name__)
+import logging
 import os
-# import re # No longer needed
 from dotenv import load_dotenv
-from tqdm import tqdm # Still needed for progress bar
+from tqdm import tqdm
 
 from .data import GSM8KDataset
 from .solvers import GSM8KSolver
 from .utils.args import parse_arguments
-from .utils.logging import setup_logging # Import the new logging setup function
+from .utils.logging import setup_logging
 
 # Load environment variables from .env file
 load_dotenv()
 
-# TqdmLoggingHandler class definition removed
 
 def main():
-    args = parse_arguments() # Call the new function for argument parsing
+    args = parse_arguments()
 
-    # Call the new logging setup function
     setup_logging(args.log_level)
     
     # Get a logger for the main module, after setup_logging has configured the root logger
     logger = logging.getLogger(__name__)
-
-    # Logging level info message is now part of setup_logging, or can be emitted here if preferred
-    # logger.info(f"Logging level set to {args.log_level}") # This is implicitly handled by setup_logging
 
     if not os.getenv("OPENROUTER_API_KEY"):
         logger.error("OPENROUTER_API_KEY environment variable not set.")
@@ -68,49 +62,12 @@ def main():
         question = example["question"]
         true_answer_full = example["answer"]
 
-        # The true answer extraction will now be handled by the solver or post-processing of GSM8KResult
-        # For now, we expect the solver to provide this if needed, or we adapt the loop later.
-        # true_answer_extracted = extract_gsm8k_answer(true_answer_full) # This line is removed
-
-        # Placeholder for where true_answer_extracted would be used or checked.
-        # This logic will need to be updated based on how GSM8KResult is used.
-        # For this subtask, we are only moving the function.
-        # The direct usage of true_answer_extracted here will be addressed in a future step.
-        # For now, we'll assume it might be None and adapt the condition slightly,
-        # acknowledging this part of main() will change.
-
-        # Simulating that we might not have it directly here anymore for the check.
-        # This part of the code (main function) will be updated in a subsequent task
-        # to correctly use the GSM8KResult object returned by solver.solve().
-        # For now, to make the file syntactically valid after removing extract_gsm8k_answer,
-        # we'll have to adjust or temporarily comment out its direct usage.
-        # For the purpose of this step (moving the function), we will remove the direct call
-        # and the immediate check. The actual handling of results will be in a later task.
-
-        # if true_answer_extracted is None: # This check will need to be re-evaluated
-        # print(
-        # "Warning: Could not extract ground truth answer for example {i+1}. Skipping."
-        # )
-        # if args.verbose:
-        # print(f"  Question: {question}")
-        # print(f"  Full Ground Truth: {true_answer_full}")
-        # continue
-        # total_examples += 1 # This also needs to be handled carefully
-
-        # Call the solver - MODIFIED
         result = solver.solve(question, true_answer_full)
 
-        # Check if true answer could be extracted (using result object) - MODIFIED
         if result.extracted_true_answer is None:
-            # total_examples was incremented before this check in the previous version,
-            # which was incorrect. We should only count examples where ground truth is extractable.
-            # So, we print the warning and skip.
             logger.warning(
                 f"Could not extract ground truth answer for example {i+1} (Q: {result.question[:50]}...). Skipping."
             )
-            # The solver handles its own verbose printing for the attempt.
-            # This verbose block is for main.py's context of *skipping*.
-            # We can use logger.debug for information previously shown with verbose flag
             logger.debug(f"  Skipped Question: {result.question}")
             logger.debug(f"  Full Ground Truth for Skipped: {result.true_answer_full}")
             continue
@@ -118,12 +75,6 @@ def main():
         # If we reach here, ground truth was extractable.
         total_examples += 1
 
-        # Verbose printing for individual example processing is REMOVED from here.
-        # It's now handled by the solver based on the verbose flag passed to it.
-
-        # Compare answers (using result object) - MODIFIED
-        # Correctness requires both extracted_model_answer and extracted_true_answer to be non-None and equal.
-        # extracted_true_answer is confirmed non-None by the check above.
         if result.extracted_model_answer is not None and \
            result.extracted_model_answer == result.extracted_true_answer:
             correct_answers += 1

--- a/src/llm_benchmarks/model/model.py
+++ b/src/llm_benchmarks/model/model.py
@@ -2,7 +2,6 @@ import os
 from openai import OpenAI
 from dotenv import load_dotenv
 
-# Load environment variables from a .env file
 load_dotenv()
 
 

--- a/src/llm_benchmarks/solvers/gsm8k_solver.py
+++ b/src/llm_benchmarks/solvers/gsm8k_solver.py
@@ -4,7 +4,7 @@ from llm_benchmarks.model.model import OpenRouterPrompt
 
 logger = logging.getLogger(__name__)
 
-# Definition of GSM8KResult (NEW)
+
 class GSM8KResult:
     def __init__(
         self,
@@ -20,31 +20,23 @@ class GSM8KResult:
         self.true_answer_full = true_answer_full
         self.extracted_true_answer = extracted_true_answer
 
-# Assume extract_gsm8k_answer is defined here or imported for now
-# For example:
-# from ..main import extract_gsm8k_answer, GSM8K_ANSWER_REGEX
-# Or it will be moved here in a subsequent step. For this subtask, we will add a placeholder.
 
-# Moved from main.py (NEW)
 GSM8K_ANSWER_REGEX = r"#### (\d+\.?\d*)"
 
-def extract_gsm8k_answer(answer_str: str) -> str | None: # Moved from main.py (NEW)
+def extract_gsm8k_answer(answer_str: str) -> str | None:
     match = re.search(GSM8K_ANSWER_REGEX, answer_str)
     if match:
         return match.group(1)
     return None
 
 class GSM8KSolver:
-    def __init__(self, model_name: str, prompt_template: str): # verbose parameter removed
+    def __init__(self, model_name: str, prompt_template: str):
         self.model = OpenRouterPrompt(prompt=prompt_template, model=model_name)
         self.prompt_template = prompt_template
-        # self.verbose = verbose removed
 
     def solve(self, question: str, true_answer_full: str) -> GSM8KResult:
-        # Prompt the model
         model_response = self.model.execute_prompt(content=question)
 
-        # Extract the answer from model's response
         match_model = re.search(r"The final answer is \$?([\d,]*\.?\d+)", model_response)
         if match_model:
             extracted_model_answer = match_model.group(1).replace(',', '')
@@ -55,18 +47,14 @@ class GSM8KSolver:
         else:
             extracted_model_answer = None
 
-        # Extract the true answer from the provided full string
-        # This will use the actual moved/imported function in later steps
-        extracted_true_answer = extract_gsm8k_answer(true_answer_full) # Using moved function
+        extracted_true_answer = extract_gsm8k_answer(true_answer_full)
 
-        # Verbose printing logic changed to logger.debug and condition removed
         logger.debug(f"Question: {question}")
         logger.debug(f"Ground Truth Answer (Full): {true_answer_full}")
         logger.debug(f"Ground Truth Answer (Extracted): {extracted_true_answer}")
         logger.debug(f"Model's Full Response: {model_response}")
         logger.debug(f"Model's Predicted Answer (Extracted): {extracted_model_answer}")
 
-        # A prediction is correct if both extracted answers are not None and they match.
         is_correct = (
             extracted_model_answer is not None
             and extracted_true_answer is not None
@@ -82,6 +70,5 @@ class GSM8KSolver:
             extracted_true_answer=extracted_true_answer,
         )
 
-    def __call__(self, question: str, true_answer_full: str) -> GSM8KResult: # Signature remains the same
-        # MODIFIED LINE:
+    def __call__(self, question: str, true_answer_full: str) -> GSM8KResult:
         return self.solve(question, true_answer_full=true_answer_full)

--- a/src/llm_benchmarks/utils/args.py
+++ b/src/llm_benchmarks/utils/args.py
@@ -5,69 +5,59 @@ def parse_arguments():
     """Parses command-line arguments."""
     parser = argparse.ArgumentParser(description="LLM Benchmarking CLI")
     parser.add_argument(
-        "--model-name",  # Changed from model_name
+        "--model-name",
         type=str,
         default="mistralai/mistral-7b-instruct",
         help="Name of the model to use from OpenRouter.",
-        dest="model_name",  # Keep dest as model_name
+        dest="model_name",
     )
     parser.add_argument(
         "--prompt-keyword",
         type=str,
         default="default",
-        choices=get_available_prompts(), # Dynamically set choices
+        choices=get_available_prompts(),
         help="Keyword for the prompt to use. Corresponding <keyword>.txt file must exist in the prompts directory.",
-        dest="prompt_keyword", # Store the keyword here
+        dest="prompt_keyword",
     )
     parser.add_argument(
-        "--num-examples",  # Changed from num_examples
+        "--num-examples",
         type=int,
         default=10,
         help="Number of examples to run from the test set. Set to -1 to run all.",
-        dest="num_examples",  # Keep dest as num_examples
+        dest="num_examples",
     )
     parser.add_argument(
-        "--data-split",  # Changed from data_split
+        "--data-split",
         type=str,
         default="test",
         choices=["train", "test"],
         help="Dataset split to use for benchmarking.",
-        dest="data_split",  # Keep dest as data_split
+        dest="data_split",
     )
     parser.add_argument(
-        "--data-config",  # Changed from data_config
+        "--data-config",
         type=str,
         default="main",
         choices=["main", "socratic"],
         help="Dataset configuration to use.",
-        dest="data_config",  # Keep dest as data_config
+        dest="data_config",
     )
-    # --verbose argument removed
     parser.add_argument(
         "--log-level",
         type=str,
         default="INFO",
-        choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"], # Reinstate choices
-        help="Set the logging level. Must be one of: DEBUG, INFO, WARNING, ERROR, CRITICAL.", # Update help
+        choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
+        help="Set the logging level. Must be one of: DEBUG, INFO, WARNING, ERROR, CRITICAL.",
         dest="log_level",
     )
     args = parser.parse_args()
 
-    # Load the prompt content using the keyword from args.prompt_keyword
-    # and store it in args.prompt_template
     try:
-        # args.prompt_keyword will exist due to dest="prompt_keyword"
-        # The actual prompt content will be stored in args.prompt_template
         args.prompt_template = load_prompt(args.prompt_keyword)
     except FileNotFoundError:
-        # This path should ideally not be hit if 'choices' and 'default' work as expected,
-        # but it's a good safeguard.
         parser.error(
             f"Selected prompt file for keyword '{args.prompt_keyword}' not found. "
             f"Available prompts: {', '.join(get_available_prompts())}"
         )
-        # The line below is effectively dead code if parser.error exits, which it does.
-        # Keep for clarity if parser.error behavior changes or is mocked in a test.
-        # raise  # Re-raise the FileNotFoundError or handle appropriately
 
     return args

--- a/src/llm_benchmarks/utils/logging.py
+++ b/src/llm_benchmarks/utils/logging.py
@@ -7,7 +7,6 @@ class AppNameFilter(logging.Filter):
         self.app_name = app_name
 
     def filter(self, record):
-        # Allow any records that start with your app's name
         return record.name.startswith(self.app_name)
 
 class TqdmLoggingHandler(logging.Handler):
@@ -29,35 +28,20 @@ def setup_logging(log_level_str: str = "INFO"):
     # Set the root logger's level
     numeric_log_level = getattr(logging, log_level_str.upper(), logging.INFO)
     if not isinstance(numeric_log_level, int):
-        # Fallback to INFO if parsing fails, and log a warning.
-        # This case should ideally be prevented by argparser choices,
-        # but as a safeguard:
+        # Fallback to INFO if parsing fails (e.g., invalid string from args).
         root_logger.warning(f"Invalid log level string: {log_level_str}. Defaulting to INFO.")
         numeric_log_level = logging.INFO
     root_logger.setLevel(numeric_log_level)
 
-    # Create and configure the TqdmLoggingHandler
     handler = TqdmLoggingHandler()
     handler.setFormatter(logging.Formatter('%(levelname)s: %(message)s'))
 
     handler.addFilter(AppNameFilter("llm_benchmarks"))
 
-    # Clear existing handlers and add the new one
     if root_logger.hasHandlers():
         root_logger.handlers.clear()
     root_logger.addHandler(handler)
 
-    # After setup, you might want to ensure the handler also respects the numeric_log_level
-    # This is important if the handler itself had a more restrictive level set by default.
-    # TqdmLoggingHandler's default level is NOTSET, so it will respect the logger's level.
-    # If it were e.g. logging.WARNING, it wouldn't show INFO messages even if logger is set to INFO.
-    # handler.setLevel(numeric_log_level) # Usually TqdmLoggingHandler is NOTSET by default.
-                                        # If it were more restrictive, this line would be crucial.
-                                        # For TqdmLoggingHandler as written, it's not strictly needed
-                                        # as it defaults to NOTSET and thus inherits logger's level.
-                                        # However, explicitly setting it can be a good practice for clarity
-                                        # or if the handler's default might change.
-                                        # For now, let's assume TqdmLoggingHandler remains NOTSET.
-
-    # Initial log message to confirm setup (optional)
-    # logging.getLogger(__name__).info(f"Logging configured with level {log_level_str.upper()}.")
+    # Note: TqdmLoggingHandler defaults to level NOTSET, so it inherits the logger's level.
+    # Explicitly setting handler.setLevel(numeric_log_level) is not strictly needed here
+    # but can be a good practice if a handler might have a more restrictive default.


### PR DESCRIPTION
I've cleaned comments across your codebase to improve readability and maintainability.

Key actions I took:
- Removed comments related to the development process, such as TODOs, notes about refactoring steps (e.g., "moved from", "NEW", "MODIFIED LINE").
- Deleted comments for obsolete code or imports (e.g., `# import re # No longer needed`).
- Removed or condensed overly verbose comments that stated the obvious or where the code was self-explanatory.
- Preserved docstrings, comments explaining complex logic, and necessary clarifications (e.g., purpose of `__main__.py`).

Files affected include:
- `src/llm_benchmarks/main.py`
- `src/llm_benchmarks/solvers/gsm8k_solver.py`
- `src/llm_benchmarks/data/gsm8k.py`
- `src/llm_benchmarks/model/model.py`
- `src/llm_benchmarks/utils/args.py`
- `src/llm_benchmarks/utils/logging.py`

Other files like `utils/prompt_utils.py` and various `__init__.py` files were reviewed but required no changes as they were already clean.

Non-integration tests (47) passed successfully after these changes. Integration tests requiring API keys were skipped and are unaffected by these comment-only modifications.