### PR TITLE
Okay, I've added exponential backoff to the OpenAI API calls.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "pytest-mock>=3.14.1",
     "ruff>=0.11.13",
     "tqdm",
+    "tenacity>=8.2.3,<9.0.0",
 ]
 
 [project.scripts]


### PR DESCRIPTION
This means I've implemented exponential backoff for calls to the OpenAI API via the OpenRouter client. This should make our interactions more resilient to temporary network problems or API rate limits.

Here's what I did:
- I added the `tenacity` library as a dependency.
- I updated the `OpenRouterPrompt.execute_prompt` method to automatically retry if there's an `openai.APIConnectionError`. It will try up to 5 times with increasing delays between attempts (up to a maximum of 60 seconds).
- I added a new unit test (`test_execute_prompt_with_retry`) in `tests/test_model.py` to make sure this retry behavior works as expected. This test simulates API connection errors and confirms that the call eventually succeeds after a few retries.
- I also refined an existing test (`test_execute_prompt_handles_api_error`) to specifically check for an `AuthenticationError` if API keys are missing. This ensures it doesn't accidentally pass because of the new retry logic for connection issues.