### PR TITLE
feat: Implement asynchronous processing for benchmark speedup

### DIFF
--- a/src/llm_benchmarks/solvers/gsm8k_solver.py
+++ b/src/llm_benchmarks/solvers/gsm8k_solver.py
@@ -1,6 +1,7 @@
 import logging
 import re
 import json
+import asyncio # Added asyncio
 from llm_benchmarks.model.model import OpenRouterPrompt
 from llm_benchmarks.cache.cache import CacheManager
 from openai.types.chat.chat_completion import ChatCompletion
@@ -92,7 +93,7 @@ class GSM8KSolver:
             return extracted_answer
         return None
 
-    def solve(self, question: str, true_answer_full: str) -> GSM8KResult:
+    async def solve(self, question: str, true_answer_full: str) -> GSM8KResult: # Changed to async def
         logger.debug(f"Solving question for model {self.model_name}: {question[:100]}...")
         if self.data_split and self.data_config and self.prompt_template_name: # Log only if available
             logger.debug(f"Data split: {self.data_split}, config: {self.data_config}, prompt: {self.prompt_template_name}")
@@ -132,7 +133,7 @@ class GSM8KSolver:
         else:
              logger.debug(f"Caching not attempted or not configured. Executing model prompt for model {self.model_name}.")
 
-        model_response_obj: ChatCompletion | None = self.model.execute_prompt(content=question)
+        model_response_obj: ChatCompletion | None = await self.model.execute_prompt(content=question) # Added await
 
         model_response_text: str | None = None
         if model_response_obj:
@@ -195,5 +196,5 @@ class GSM8KSolver:
             extracted_true_answer=extracted_true_answer,
         )
 
-    def __call__(self, question: str, true_answer_full: str) -> GSM8KResult:
-        return self.solve(question, true_answer_full=true_answer_full)
+    async def __call__(self, question: str, true_answer_full: str) -> GSM8KResult: # Changed to async def
+        return await self.solve(question, true_answer_full=true_answer_full) # Added await

--- a/src/llm_benchmarks/utils/args.py
+++ b/src/llm_benchmarks/utils/args.py
@@ -43,6 +43,13 @@ def parse_arguments():
         dest="data_config",
     )
     parser.add_argument(
+        "--concurrency",
+        type=int,
+        default=10,
+        help="Set the maximum number of concurrent requests to the LLM API. Default is 10.",
+        dest="concurrency",
+    )
+    parser.add_argument(
         "--log-level",
         type=str,
         default="INFO",


### PR DESCRIPTION
This commit introduces asynchronous operations to significantly speed up the benchmark execution by making concurrent API calls to the LLM.

Key changes:
- Modified `OpenRouterPrompt` to use `AsyncOpenAI` and `async def` for prompt execution, allowing non-blocking API calls.
- Updated `GSM8KSolver` to be asynchronous, awaiting results from the model.
- Revamped `run_benchmarks` in `main.py` to use `asyncio.gather` (later changed to `asyncio.as_completed` for better progress updates) for concurrent task execution.
- Introduced a command-line argument `--concurrency` (defaulting to 10) to control the maximum number of parallel API requests, managed by an `asyncio.Semaphore`.
- Updated the main entry point to use `asyncio.run`.
- Ensured Tenacity retry mechanisms are compatible with async methods.

The synchronous nature of the caching mechanism is retained for now and can be a subject for future optimization if cache I/O becomes a bottleneck.

These changes allow the benchmark to process multiple examples in parallel, reducing overall runtime, especially for larger datasets or slower API responses.