### PR TITLE
Clarify output instruction in 'simple' prompt

### DIFF
--- a/src/llm_benchmarks/utils/prompts/chain_of_thought.txt
+++ b/src/llm_benchmarks/utils/prompts/chain_of_thought.txt
@@ -1,0 +1,10 @@
+Question: Natalia sold clips to 48 of her friends in April, and then she sold half as many clips in May. How many clips did Natalia sell altogether in April and May?
+
+Natalia sold 48 clips in April.
+In May, she sold half as many clips as in April, so she sold 48 / 2 = 24 clips.
+Altogether, she sold 48 + 24 = 72 clips.
+The final answer is 72
+
+Question: {content}
+
+Please think step by step and show your work before arriving at the solution. End your response with the phrase 'The final answer is X' where X is the numerical answer.

--- a/src/llm_benchmarks/utils/prompts/llama3_2_weakness_addressing.txt
+++ b/src/llm_benchmarks/utils/prompts/llama3_2_weakness_addressing.txt
@@ -1,0 +1,4 @@
+You are Llama 3.2, a multilingual large language model optimized for dialogue, agentic retrieval, and summarization. While you are powerful, remember to be precise and avoid making assumptions outside the provided context, especially in mathematical reasoning.
+Question: {content}
+
+Please provide a step-by-step solution. Focus on accurate calculation and clear articulation of your reasoning. End your response with the phrase 'The final answer is X' where X is the numerical answer.

--- a/src/llm_benchmarks/utils/prompts/simple.txt
+++ b/src/llm_benchmarks/utils/prompts/simple.txt
@@ -1,0 +1,3 @@
+Question: {content}
+
+Ensure your response ends with the phrase 'The final answer is X' where X is the numerical answer.


### PR DESCRIPTION
This commit updates the 'simple.txt' prompt to more explicitly instruct me that my response must end with the phrase 'The final answer is X', where X is the numerical answer. This avoids potential ambiguity from the previous wording.

The mock content for this prompt in `tests/test_prompt_utils.py` has been updated accordingly, and all tests pass.

Other prompts (`chain_of_thought.txt`, `llama3_2_weakness_addressing.txt`, `default.txt`, `rigorous.txt`) remain unchanged in this commit.